### PR TITLE
fix(E15): `pasta.context(savepoint)` throws E15 when `&indentexpr ==# ''`

### DIFF
--- a/lua/pasta/init.lua
+++ b/lua/pasta/init.lua
@@ -165,9 +165,14 @@ end
 ---@return { new_indent: string }
 function pasta.context(savepoint)
   vim.cmd(vim.api.nvim_replace_termcodes('normal! <Esc>o', true, true, true))
-  local new_indent = string.rep(' ', vim.api.nvim_eval(vim.bo.indentexpr))
-  if not vim.bo.expandtab then
-    new_indent = new_indent:gsub(string.rep(' ', vim.bo.shiftwidth ~= 0 and vim.bo.shiftwidth or vim.bo.tabstop), '\t')
+  local new_indent
+  if vim.bo.indentexpr ~= '' then
+    new_indent = string.rep(' ', vim.api.nvim_eval(vim.bo.indentexpr))
+    if not vim.bo.expandtab then
+      new_indent = new_indent:gsub(string.rep(' ', vim.bo.shiftwidth ~= 0 and vim.bo.shiftwidth or vim.bo.tabstop), '\t')
+    end
+  else
+    new_indent = ''
   end
 
   local context = {


### PR DESCRIPTION
## What's Changed

```vim
&indentexpr ==# ''
```

の際に`require('pasta.mappings').p`がエラーとなり、
ペーストの動作が実行されない挙動を修正する。

## Error Message

`lua/pasta/init.lua:168: Vim:E15: 無効な式です:`
